### PR TITLE
Fix GitHub Alerts false positives

### DIFF
--- a/.remarkrc.js
+++ b/.remarkrc.js
@@ -3,6 +3,21 @@ import presetLintRecommended from 'remark-preset-lint-recommended';
 import validateLinks from 'remark-validate-links';
 import presetPrettier from 'remark-preset-prettier';
 
+// NOTE: Support Alerts on GitHub Markdown.
+// See https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#alerts
+const overriddenLintNoUndefinedReferences = [
+	'remark-lint-no-undefined-references',
+	{
+		allow: ['!NOTE', '!TIP', '!IMPORTANT', '!WARNING', '!CAUTION'],
+	},
+];
+
 export default {
-	plugins: [frontmatter, presetLintRecommended, validateLinks, presetPrettier],
+	plugins: [
+		frontmatter,
+		presetLintRecommended,
+		validateLinks,
+		presetPrettier,
+		overriddenLintNoUndefinedReferences,
+	],
 };

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Head
+
+- Fixed: GitHub Alerts false positives.
+
 ## 5.0.0
 
 - Changed: update `remark` to [v15](https://github.com/remarkjs/remark/releases/tag/15.0.0) including the relevant dependencies.


### PR DESCRIPTION
Recently, GitHub supported the special syntax for Alerts like `[!NOTE]` or `[!WARNING]`.
However, `remark-lint-no-undefined-references` detects them as a problem. It's a false positive.

Ref: https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#alerts

<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

None.

> Is there anything in the PR that needs further explanation?

This setting has been done in the `stylelint/stylelint` repo:
https://github.com/stylelint/stylelint/blob/6f6abba3c64e13b2961c6ccfccd6a5b7de932822/package.json#L112-L126

I believe it's worth reusing this widely in our `stylelint` org.