### PR TITLE
Prevent creating release draft on `npm run release`

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "lint:js": "eslint . --ignore-path .gitignore",
     "lint:md": "remark . --quiet --frail --ignore-path .gitignore",
     "prepare": "husky",
-    "release": "np",
+    "release": "np --no-release-draft",
     "test": "npm run lint"
   },
   "lint-staged": {


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

None.

> Is there anything in the PR that needs further explanation?

We have already a workflow to automatically create releases:
https://github.com/stylelint/remark-preset/blob/14b496c557a86e2e8143426583182f0ddcf54fba/.github/workflows/release.yml
